### PR TITLE
NGC-3184 Add resolver for HMRC libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/te
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-u", "target/test-reports")
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
 
+resolvers += Resolver.bintrayRepo("hmrc", "releases")
+
 val playVersion = "2.5.18"
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.4" % "test",


### PR DESCRIPTION
Fixes errors trying to resolve HMRC libraries that are not already in the local ivy cache ~/.ivy2/cache