### PR TITLE
[NK] Added missing test for account blocking

### DIFF
--- a/src/test/scala/uk/gov/hmrc/ngchelptosavecontract/mobilehelptosave/AccountSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ngchelptosavecontract/mobilehelptosave/AccountSpec.scala
@@ -44,6 +44,7 @@ class AccountSpec extends AsyncWordSpec
   val beth = Nino("EM000001A")
   val accountClosedNino = Nino("EM000010A")
   val accountMissingNino = Nino("EM111111A")
+  val accountBlockedNino = Nino("EM000011A")
 
   "/help-to-save/{nino}/account" should {
 
@@ -87,8 +88,16 @@ class AccountSpec extends AsyncWordSpec
         account.closingBalance should not be None
       }
     }
-  }
 
+    s"return blocked account ($accountBlockedNino)" in {
+
+      withLoggedInUser(accountBlockedNino) { implicit hc =>
+
+        val account = getAccountFor(accountBlockedNino)
+        account.blocked.unspecified shouldBe true
+      }
+    }
+  }
 
   private def getAccountFor(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Account = {
     await(httpRequests.getAccountFor(nino)).as[Account]


### PR DESCRIPTION
Recently have test failing on multi-service test related to blocking, then we realised we should have captured this earlier at a contract test level.